### PR TITLE
Jdavredbeard/more type remaps

### DIFF
--- a/Aws.fs
+++ b/Aws.fs
@@ -243,6 +243,8 @@ let cloudformationMappings = function
 | "ElasticLoadBalancingV2", "ListenerCertificate" -> "lb", "ListenerCertificate"
 | "ElasticLoadBalancingV2", "ListenerRule" -> "lb", "ListenerRule"
 | "Lambda", "EventInvokeConfig" -> "lambda", "FunctionEventInvokeConfig"
+| "Lambda", "LayerVersionPermission" -> "lambda", "LayerVersionPermission"
+| "OpenSearchService", "Domain" -> "opensearch", "Domain"
 | "Route53", "RecordSet" -> "route53", "Record"
 | "Route53", "HostedZone" -> "route53", "Zone"
 | "Route53Resolver", "ResolverEndpoint" -> "route53", "ResolverEndpoint"

--- a/Aws.fs
+++ b/Aws.fs
@@ -249,8 +249,11 @@ let cloudformationMappings = function
 | "Route53Resolver", "ResolverEndpoint" -> "route53", "ResolverEndpoint"
 | "Route53Resolver", "ResolverRule" -> "route53", "ResolverRule"
 | "Route53Resolver", "ResolverRuleAssociation" -> "route53", "ResolverRuleAssociation"
-| "SNS", "Subscription" -> "sns", "TopicSubscription"
+| "RDS", "DBCluster" -> "rds", "Cluster"
+| "RDS", "DBInstance" -> "rds", "Instance"
+| "RDS", "DBSubnetGroup" -> "rds", "SubnetGroup"
 | "SNS", "Topic" -> "sns", "Topic"
+| "SNS", "Subscription" -> "sns", "TopicSubscription"
 | "CertificateManager", "Certificate" -> "acm", "Certificate"
 | "CloudWatch", "Alarm" -> "cloudwatch", "MetricAlarm"
 | moduleName, resourceType -> moduleName, resourceType

--- a/Aws.fs
+++ b/Aws.fs
@@ -211,7 +211,6 @@ let cloudformationMappings = function
 | "Amplify", "Domain" -> "Amplify", "DomainAssociation"
 | "AutoScaling", "AutoScalingGroup" -> "Autoscaling", "Group"
 | "CloudFront", "CloudFrontOriginAccessIdentity" -> "cloudfront", "originAccessIdentity"
-| "SNS", "Topic" -> "sns", "TopicSubscription"
 | "EC2", "DHCPOptions" -> "EC2", "VpcDhcpOptions"
 | "EC2", "EC2Fleet" -> "EC2", "Fleet"
 | "EC2", "EIP" -> "EC2", "Eip"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "pulumi-importer",
+    "name": "pulumi-tool-importer-fork",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,6 +2,7 @@ source https://api.nuget.org/v3/index.json
 framework: net6.0
 storage: none
 
+nuget AWSSDK.CloudControlApi
 nuget Feliz.SelectSearch 1.8.0
 nuget Fsharp.Core ~> 6
 nuget Fable.Remoting.Giraffe

--- a/paket.lock
+++ b/paket.lock
@@ -2,6 +2,9 @@ STORAGE: NONE
 RESTRICTION: == net6.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
+    AWSSDK.CloudControlApi (3.7.400.33)
+      AWSSDK.Core (>= 3.7.400.33 < 4.0)
+    AWSSDK.Core (3.7.400.33)
     Expecto (9.0.4)
       FSharp.Core (>= 4.6)
       Mono.Cecil (>= 0.11.3)

--- a/src/Client/Client.fsproj
+++ b/src/Client/Client.fsproj
@@ -1,29 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <DefineConstants>FABLE_COMPILER</DefineConstants>
-    </PropertyGroup>
-    <ItemGroup>
-        <None Include="index.html" />
-        <Compile Include="Server.fs" />
-        <Compile Include="Utilities.fs" />
-        <Compile Include="Import.fs" />
-        <Compile Include="Aws.fs" />
-        <Compile Include="Azure.fs" />
-        <Compile Include="Google.fs" />
-        <Compile Include="Index.fs" />
-        <Compile Include="App.fs" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\Shared\Shared.fsproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <PackageReference Include="Fable.Remoting.Client" Version="7.25.0" />
-      <PackageReference Include="Feliz.Markdown" Version="2.4.0" />
-      <PackageReference Include="Feliz.UseDeferred" Version="2.0.0" />
-      <PackageReference Include="Feliz.Router" Version="4.0.0" />
-      <PackageReference Include="Feliz" Version="2.4.0" />
-      <PackageReference Include="Feliz.SelectSearch" Version="3.1.0" />
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <DefineConstants>FABLE_COMPILER</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="index.html" />
+    <Compile Include="Server.fs" />
+    <Compile Include="Utilities.fs" />
+    <Compile Include="Import.fs" />
+    <Compile Include="Aws.fs" />
+    <Compile Include="Azure.fs" />
+    <Compile Include="Google.fs" />
+    <Compile Include="Index.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Fable.Remoting.Client" Version="7.25.0" />
+    <PackageReference Include="Feliz.Markdown" Version="2.4.0" />
+    <PackageReference Include="Feliz.UseDeferred" Version="2.0.0" />
+    <PackageReference Include="Feliz.Router" Version="4.0.0" />
+    <PackageReference Include="Feliz" Version="2.4.0" />
+    <PackageReference Include="Feliz.SelectSearch" Version="3.1.0" />
+  </ItemGroup>
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Server/AwsCloudFormation.fs
+++ b/src/Server/AwsCloudFormation.fs
@@ -937,7 +937,7 @@ let mapToPulumi = function
 // | "AWS::OpenSearchServerless::SecurityConfig" -> Error "not found"
 // | "AWS::OpenSearchServerless::SecurityPolicy" -> Error "not found"
 // | "AWS::OpenSearchServerless::VpcEndpoint" -> Error "not found"
-// | "AWS::OpenSearchService::Domain" -> Error "not found"
+| "AWS::OpenSearchService::Domain" -> Some "aws:opensearch/domain:Domain"
 // | "AWS::OpsWorks::App" -> Error "not found"
 // | "AWS::OpsWorks::ElasticLoadBalancerAttachment" -> Error "not found"
 | "AWS::OpsWorks::Instance" -> Some "aws:opsworks/instance:Instance"
@@ -1322,4 +1322,4 @@ let mapToPulumi = function
 // | "Alexa::ASK::Skill" -> Error "not found"
 | _ -> None
 
-// Mapped number of types: 639 / 1314 (remaining: 675)
+// Mapped number of types: 640 / 1314 (remaining: 674)

--- a/src/Server/AwsCloudFormation.fs
+++ b/src/Server/AwsCloudFormation.fs
@@ -1014,16 +1014,16 @@ let mapToPulumi = function
 // | "AWS::RAM::Permission" -> Error "not found"
 | "AWS::RAM::ResourceShare" -> Some "aws:ram/resourceShare:ResourceShare"
 | "AWS::RDS::CustomDBEngineVersion" -> Some "aws:rds/customDbEngineVersion:CustomDbEngineVersion"
-// | "AWS::RDS::DBCluster" -> Error "not found"
+| "AWS::RDS::DBCluster" -> Some "aws:rds/cluster:Cluster"
 // | "AWS::RDS::DBClusterParameterGroup" -> Error "not found"
-// | "AWS::RDS::DBInstance" -> Error "not found"
+| "AWS::RDS::DBInstance" -> Some "aws:rds/instance:Instance"
 // | "AWS::RDS::DBParameterGroup" -> Error "not found"
 // | "AWS::RDS::DBProxy" -> Error "not found"
 // | "AWS::RDS::DBProxyEndpoint" -> Error "not found"
 // | "AWS::RDS::DBProxyTargetGroup" -> Error "not found"
 // | "AWS::RDS::DBSecurityGroup" -> Error "not found"
 // | "AWS::RDS::DBSecurityGroupIngress" -> Error "not found"
-// | "AWS::RDS::DBSubnetGroup" -> Error "not found"
+| "AWS::RDS::DBSubnetGroup" -> Some "aws:rds/subnetGroup:SubnetGroup"
 | "AWS::RDS::EventSubscription" -> Some "aws:rds/eventSubscription:EventSubscription"
 | "AWS::RDS::GlobalCluster" -> Some "aws:rds/globalCluster:GlobalCluster"
 // | "AWS::RDS::Integration" -> Error "not found"
@@ -1322,4 +1322,4 @@ let mapToPulumi = function
 // | "Alexa::ASK::Skill" -> Error "not found"
 | _ -> None
 
-// Mapped number of types: 633 / 1314 (remaining: 681)
+// Mapped number of types: 639 / 1314 (remaining: 675)

--- a/src/Server/AwsCloudFormationTemplates.fs
+++ b/src/Server/AwsCloudFormationTemplates.fs
@@ -237,6 +237,24 @@ let remapLayerVersionPermission
         importId = importId
     }
 
+let remapTransferServer
+    (resource: AwsCloudFormationResource)
+    (resourceData: Dictionary<string, Dictionary<string,string>>)
+    (resourceContext: AwsResourceContext)
+    (spec: CustomRemapSpecification) 
+    : RemappedSpecResult =
+    let data = resourceData[resource.logicalId]
+    let serverPhysicalIdParts = data["Id"].Split("/")
+    let serverId = serverPhysicalIdParts[1]
+    let importId = serverId
+    let resourceType = spec.pulumiType
+    let logicalId = resource.logicalId.Replace("-", "_")
+    {
+        resourceType = resourceType
+        logicalId = logicalId
+        importId = importId
+    }
+
 let remapSpecifications = Map.ofList [
     "AWS::ApiGateway::Resource" => {
         pulumiType = "aws:apigateway/resource:Resource"
@@ -401,6 +419,22 @@ let remapSpecifications = Map.ofList [
         pulumiType = getPulumiType "AWS::SQS::QueuePolicy"
         importIdentityParts = ["Queues"]
         delimiter = ""
+        remapFunc = remapFromImportIdentityParts
+        validatorFunc = validateFromImportIdentityParts
+    }
+
+    "AWS::Transfer::Server" => {
+        pulumiType = getPulumiType "AWS::Transfer::Server"
+        importIdentityParts = ["Id"]
+        delimiter = ""
+        remapFunc = remapTransferServer
+        validatorFunc = validateFromImportIdentityParts
+    }
+
+    "AWS::Transfer::User" => {
+        pulumiType = getPulumiType "AWS::Transfer::User"
+        importIdentityParts = ["ServerId"; "UserName"]
+        delimiter = "/"
         remapFunc = remapFromImportIdentityParts
         validatorFunc = validateFromImportIdentityParts
     }

--- a/src/Server/AwsCloudFormationTemplates.fs
+++ b/src/Server/AwsCloudFormationTemplates.fs
@@ -166,7 +166,7 @@ let filterSecurityGroupRules
     |> Map.filter (fun id props ->
         data
         |> Seq.forall (fun entry ->
-            if entry.Key = "Id" then true
+            if entry.Key = "Id" || entry.Key = "resourceType" then true
             elif props.ContainsKey entry.Key then
                 let prop = props.Property(entry.Key)
                 prop.Value.ToString() = data[prop.Name]
@@ -270,6 +270,14 @@ let remapSpecifications = Map.ofList [
         validatorFunc = validateFromImportIdentityParts
     }
 
+    "AWS::Cognito::UserPoolClient" => {
+        pulumiType = getPulumiType "AWS::Cognito::UserPoolClient"
+        importIdentityParts = ["UserPoolId"; "Id"]
+        delimiter = "/"
+        remapFunc = remapFromImportIdentityParts
+        validatorFunc = validateFromImportIdentityParts
+    }
+
     "AWS::EC2::SubnetRouteTableAssociation" => {
         pulumiType = getPulumiType "AWS::EC2::SubnetRouteTableAssociation"
         importIdentityParts = ["SubnetId"; "RouteTableId"]
@@ -355,6 +363,14 @@ let remapSpecifications = Map.ofList [
         pulumiType = getPulumiType "AWS::S3::BucketPolicy"
         importIdentityParts = ["Bucket"]
         delimiter = "/"
+        remapFunc = remapFromImportIdentityParts
+        validatorFunc = validateFromImportIdentityParts
+    }
+
+    "AWS::SQS::QueuePolicy" => {
+        pulumiType = getPulumiType "AWS::SQS::QueuePolicy"
+        importIdentityParts = ["Queues"]
+        delimiter = ""
         remapFunc = remapFromImportIdentityParts
         validatorFunc = validateFromImportIdentityParts
     }

--- a/src/Server/AwsCloudFormationTemplates.fs
+++ b/src/Server/AwsCloudFormationTemplates.fs
@@ -169,7 +169,6 @@ let filterSecurityGroupRules
             if entry.Key = "Id" then true
             elif props.ContainsKey entry.Key then
                 let prop = props.Property(entry.Key)
-                printfn "%A %A %A %A" id prop.Name (prop.Value.ToString()) data[prop.Name]
                 prop.Value.ToString() = data[prop.Name]
             else false
         ))
@@ -184,7 +183,6 @@ let remapSecurityGroupIngress
     let filteredRules = filterSecurityGroupRules data resourceContext.securityGroupIngressRules
     let importId =
         if not ((Seq.length filteredRules) = 1) then 
-            printfn "%A" (Seq.length filteredRules)
             ""
         else (Seq.exactlyOne filteredRules).Key
     
@@ -206,7 +204,6 @@ let remapSecurityGroupEgress
     let filteredRules = filterSecurityGroupRules data resourceContext.securityGroupEgressRules
     let importId =
         if not ((Seq.length filteredRules) = 1) then 
-            printfn "%A" (Seq.length filteredRules)
             ""
         else (Seq.exactlyOne filteredRules).Key
     

--- a/src/Server/AwsCloudFormationTypes.fs
+++ b/src/Server/AwsCloudFormationTypes.fs
@@ -24,15 +24,6 @@ type AwsResourceContext = {
     securityGroupIngressRules: Map<string,JObject>
     securityGroupEgressRules: Map<string,JObject>
 }
-  with 
-    static member Empty = {
-        loadBalancers = Map.empty
-        elasticIps = Map.empty
-        routeTables = ResizeArray []
-        iamPolicies = ResizeArray []
-        gatewayAttachmentImportIds = Dictionary()
-        securityGroupRuleIds = Dictionary()
-    }
 
 type CustomRemapSpecification = {
     pulumiType: string

--- a/src/Server/AwsCloudFormationTypes.fs
+++ b/src/Server/AwsCloudFormationTypes.fs
@@ -3,6 +3,7 @@ module AwsCloudFormationTypes
 open Amazon.EC2.Model
 open Amazon.ElasticLoadBalancingV2.Model
 open Amazon.IdentityManagement.Model
+open Newtonsoft.Json.Linq
 
 open System.Collections.Generic
 open Shared
@@ -20,7 +21,8 @@ type AwsResourceContext = {
     routeTables: List<RouteTable>
     iamPolicies: List<ManagedPolicy>
     gatewayAttachmentImportIds: Dictionary<string,string>
-    securityGroupRuleIds: Dictionary<string, seq<SecurityGroupRule>>
+    securityGroupIngressRules: Map<string,JObject>
+    securityGroupEgressRules: Map<string,JObject>
 }
 
 type CustomRemapSpecification = {

--- a/src/Server/AwsCloudFormationTypes.fs
+++ b/src/Server/AwsCloudFormationTypes.fs
@@ -39,5 +39,10 @@ type RemapSpecification = {
     importIdentityParts: string list
 }
 
+type CloudControlResourceDescription = {
+    identifier: string
+    properties: JObject
+}
+
 
 

--- a/src/Server/paket.references
+++ b/src/Server/paket.references
@@ -1,3 +1,4 @@
 Saturn
 Fable.Remoting.Giraffe
 Fsharp.Core
+AWSSDK.CloudControlApi

--- a/src/Shared/Shared.fsproj
+++ b/src/Shared/Shared.fsproj
@@ -9,4 +9,5 @@
   <ItemGroup>
     <PackageReference Include="PulumiSchemaTypes" Version="1.1.0" />
   </ItemGroup>
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
Adds resolution of Fn::GetAtt for fields that are not available in the template through calling the cloud control api 

Adds logic to match all fields on Security Group Rules to handle more cases

Changes Security Group Rule api call to use cloud control api

Adds type mappings for:
"AWS::RDS::DBCluster"
"AWS::RDS::DBInstance"
"AWS::RDS::DBSubnetGroup"
"AWS::Lambda::LayerVersionPermission"
"AWS::OpenSearchService::Domain"

Adds import id remaps for:
"AWS::Cognito::UserPoolClient"
"AWS::SQS::QueuePolicy"
"AWS::Lambda::LayerVersionPermission"