### PR TITLE
Using result types for mapping specifications

### DIFF
--- a/src/Server/AwsCloudFormationTypes.fs
+++ b/src/Server/AwsCloudFormationTypes.fs
@@ -43,6 +43,8 @@ type CustomRemapSpecification = {
     validatorFunc: AwsCloudFormationResource -> Dictionary<string, Dictionary<string,string>> -> CustomRemapSpecification -> bool
 }
 
+type RemapFunction = AwsCloudFormationResource -> Dictionary<string,string> -> AwsResourceContext -> Result<RemappedSpecResult, string>
+
 type RemapSpecification = {
     pulumiType: string
     delimiter: string

--- a/src/Server/PulumiImporter.fsproj
+++ b/src/Server/PulumiImporter.fsproj
@@ -37,6 +37,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="3.7.301.22" />
     <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="Azure.ResourceManager" Version="1.12.0" />
+    <PackageReference Include="FsToolkit.ErrorHandling" Version="4.17.0" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="1.68.0.3356" />
     <PackageReference Include="Google.Cloud.Asset.V1" Version="3.12.0" />
     <PackageReference Include="Humanizer" Version="2.14.1" />

--- a/src/Server/Server.fs
+++ b/src/Server/Server.fs
@@ -1103,6 +1103,23 @@ let getRemappedImportProps
     |> Option.filter (fun spec -> spec.validatorFunc resource resourceData spec)
     |> Option.map (fun spec -> spec.remapFunc resource resourceData resourceContext spec)
 
+let getRemappedImportPropsV2
+    (resource: AwsCloudFormationResource)
+    (resourceData: Dictionary<string, Dictionary<string,string>>)
+    (resourceContext: AwsResourceContext)
+    : Option<RemappedSpecResult> =      
+    
+    AwsCloudFormationTemplates.remapSpecificationsV2
+    |> Map.tryFind resource.resourceType
+    |> Option.filter (fun _ -> resourceData.ContainsKey resource.logicalId)
+    |> Option.bind (fun remapFunc -> 
+        let data = resourceData[resource.logicalId]
+        match remapFunc resource data resourceContext with
+        | Ok remappedSpecResult -> Some remappedSpecResult
+        | Error remapError -> None // todo: log error or return it to user
+    ) 
+
+
 let getPulumiImportJson 
     (cloudformationResources: seq<AwsCloudFormationResource>) 
     (resourceContext: AwsResourceContext)


### PR DESCRIPTION
Experimenting with a different way of doing import remaps from resource specifications